### PR TITLE
add option to allow all users

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -7,6 +7,8 @@ lasso:
   logLevel: info
   listen: 0.0.0.0
   port: 9090
+  # set allowAllUsers: true to use Lasso to just identify users rather than determine whether they are authorized
+  allowAllUsers: false
   # each of these domains must serve the url https://lasso.$domains[0] https://lasso.$domains[1] ...
   # usually you'll just have one
   domains:

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -201,9 +201,11 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Infof("email from jwt cookie: %s", claims.Email)
 
-	if !jwtmanager.SiteInClaims(r.Host, &claims) {
-		error401(w, r, AuthError{"not authorized for " + r.Host, jwt})
-		return
+	if !cfg.Cfg.AllowAllUsers {
+		if !jwtmanager.SiteInClaims(r.Host, &claims) {
+			error401(w, r, AuthError{"not authorized for " + r.Host, jwt})
+			return
+		}
 	}
 
 	// renderIndex(w, "user found from email "+user.Email)
@@ -325,6 +327,7 @@ func VerifyUser(u interface{}) (ok bool, err error) {
 		// } else if !domains.IsUnderManagement(user.HostDomain) {
 		// 	err = fmt.Errorf("HostDomain %s is not within a lasso managed domain", u.HostDomain)
 	} else {
+		log.Debugf("no domains configured")
 		ok = true
 	}
 	return ok, err

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -15,6 +15,7 @@ type CfgT struct {
 	Listen   string   `mapstructure:"listen"`
 	Port     int      `mapstructure:"port"`
 	Domains  []string `mapstructure:"domains"`
+	AllowAllUsers bool `mapstructure:"allowAllUsers"`
 	JWT      struct {
 		MaxAge   int    `mapstructure:"maxAge"`
 		Issuer   string `mapstructure:"issuer"`


### PR DESCRIPTION
requests to the backend still require a logged-in user, but enabling this option will not reject any user based on domain matching. useful when using Lasso to identify users rather than determine whether they are authorized.