### PR TITLE
allow forcing the domain of the cookie to set

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -21,6 +21,8 @@ lasso:
   cookie: 
     # name of cookie to store the jwt
     name: Lasso
+    # optionally force the domain of the cookie to set
+    # domain: yourdomain.com
     secure: false
     httpOnly: true
   headers:

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -23,6 +23,7 @@ type CfgT struct {
 	}
 	Cookie struct {
 		Name     string `mapstructure:"name"`
+		Domain   string `mapstructure:"domain"`
 		Secure   bool   `mapstructure:"secure"`
 		HTTPOnly bool   `mapstructure:"httpOnly"`
 	}

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -23,6 +23,11 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		maxAge = defaultMaxAge
 	}
 	domain := domains.Matches(r.Host)
+	// Allow overriding the cookie domain in the config file
+	if cfg.Cfg.Cookie.Domain != "" {
+	  domain = cfg.Cfg.Cookie.Domain
+		log.Debugf("setting the cookie domain to %v", domain)
+	}
 	// log.Debugf("cookie %s expires %d", cfg.Cfg.Cookie.Name, expires)
 	http.SetCookie(w, &http.Cookie{
 		Name:     cfg.Cfg.Cookie.Name,


### PR DESCRIPTION
When there are no domains configured, Lasso doesn't know where to set the cookie. This option forces the cookie domain in case there are either no domains configured, or if you need to force the cookie to a top-level domain when using subdomains.