### PR TITLE
add config option to allow public access

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -7,6 +7,8 @@ lasso:
   logLevel: info
   listen: 0.0.0.0
   port: 9090
+  # Setting publicAccess: true will accept all requests, even without a cookie. If the user is logged in, the cookie will be validated and the user header will be set.
+  publicAccess: false
   # each of these domains must serve the url https://lasso.$domains[0] https://lasso.$domains[1] ...
   # usually you'll just have one
   domains:

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -184,7 +184,12 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 	jwt := FindJWT(r)
 	// if jwt != "" {
 	if jwt == "" {
-		error401(w, r, AuthError{Error: "no jwt found"})
+		// If the module is configured to allow public access with no authentication, return 200 now
+		if !cfg.Cfg.PublicAccess {
+			error401(w, r, AuthError{Error: "no jwt found"})
+		} else {
+			w.Header().Add("X-Lasso-User", "");
+		}
 		return
 	}
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -15,6 +15,7 @@ type CfgT struct {
 	Listen   string   `mapstructure:"listen"`
 	Port     int      `mapstructure:"port"`
 	Domains  []string `mapstructure:"domains"`
+	PublicAccess bool  `mapstructure:"publicAccess"`
 	JWT      struct {
 		MaxAge   int    `mapstructure:"maxAge"`
 		Issuer   string `mapstructure:"issuer"`


### PR DESCRIPTION
setting `publicAccess: true` tells Lasso to allow requests even without a cookie. this is useful for public sites that also allow users to sign in.