### PR TITLE
fixes some crashes

### DIFF
--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -177,6 +177,7 @@ func decodeAndDecompressTokenString(encgzipss string) string {
 	zr, err := gzip.NewReader(breader)
 	if err != nil {
 		log.Debugf("Error reading gzip data: %v", err)
+		return ""
 	}
 	if err := zr.Close(); err != nil {
 		log.Debugf("Error decoding token: %v", err)

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -170,16 +170,16 @@ func decodeAndDecompressTokenString(encgzipss string) string {
 	// gzipss, err := url.QueryUnescape(encgzipss)
 	gzipss, err := base64.URLEncoding.DecodeString(encgzipss)
 	if err != nil {
-		log.Fatal(err)
+		log.Debugf("Error in Base64decode: %v", err)
 	}
 
 	breader := bytes.NewReader(gzipss)
 	zr, err := gzip.NewReader(breader)
 	if err != nil {
-		log.Fatal(err)
+		log.Debugf("Error reading gzip data: %v", err)
 	}
 	if err := zr.Close(); err != nil {
-		log.Fatal(err)
+		log.Debugf("Error decoding token: %v", err)
 	}
 	ss, _ := ioutil.ReadAll(zr)
 	return string(ss)


### PR DESCRIPTION
Since anyone can send a garbled cookie, the proxy should not crash when invalid data is sent. This changes fatal errors to debug warnings and includes more information in the logs.

Also fixes a crash if the JWT string sent contains a space.