### PR TITLE
Oauth2 bearer token support

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -30,7 +30,8 @@ lasso:
     secure: false
     httpOnly: true
   headers:
-    sso: X-Lasso-Token
+    jwt: X-Lasso-Token
+    querystring: access_token
     redirect: X-Lasso-Requested-URI
   db: 
     file: data/lasso_bolt.db

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -30,7 +30,8 @@ type CfgT struct {
 		HTTPOnly bool   `mapstructure:"httpOnly"`
 	}
 	Headers struct {
-		SSO      string `mapstructure:"sso"`
+		JWT      string `mapstructure:"jwt"`
+		QueryString string `mapstructure:"querystring"`
 		Redirect string `mapstructure:"redirect"`
 	}
 	DB struct {

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -177,6 +177,7 @@ func decodeAndDecompressTokenString(encgzipss string) string {
 	zr, err := gzip.NewReader(breader)
 	if err != nil {
 		log.Debugf("Error reading gzip data: %v", err)
+		return ""
 	}
 	if err := zr.Close(); err != nil {
 		log.Debugf("Error decoding token: %v", err)

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -170,16 +170,16 @@ func decodeAndDecompressTokenString(encgzipss string) string {
 	// gzipss, err := url.QueryUnescape(encgzipss)
 	gzipss, err := base64.URLEncoding.DecodeString(encgzipss)
 	if err != nil {
-		log.Fatal(err)
+		log.Debugf("Error in Base64decode: %v", err)
 	}
 
 	breader := bytes.NewReader(gzipss)
 	zr, err := gzip.NewReader(breader)
 	if err != nil {
-		log.Fatal(err)
+		log.Debugf("Error reading gzip data: %v", err)
 	}
 	if err := zr.Close(); err != nil {
-		log.Fatal(err)
+		log.Debugf("Error decoding token: %v", err)
 	}
 	ss, _ := ioutil.ReadAll(zr)
 	return string(ss)


### PR DESCRIPTION
Modifies `FindJWT` function to also look in the `Authorization` header for an OAuth 2.0 Bearer Token, e.g. `Authorization: Bearer XXXXXXX`

Adds a new config item to set the query string param separately from the HTTP header, so if you set it to `access_token` then it also follows the Bearer Token spec.

merge #9 first