### PR TITLE
fix for PublicAccess=true

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -196,19 +196,31 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 	claims, err := ClaimsFromJWT(jwt)
 	if err != nil {
 		// no email in jwt
-		error401(w, r, AuthError{err.Error(), jwt})
+		if !cfg.Cfg.PublicAccess {
+			error401(w, r, AuthError{err.Error(), jwt})
+		} else {
+			w.Header().Add("X-Lasso-User", "");
+		}
 		return
 	}
 	if claims.Email == "" {
 		// no email in jwt
-		error401(w, r, AuthError{"no email found in jwt", jwt})
+		if !cfg.Cfg.PublicAccess {
+			error401(w, r, AuthError{"no email found in jwt", jwt})
+		} else {
+			w.Header().Add("X-Lasso-User", "");
+		}
 		return
 	}
 	log.Infof("email from jwt cookie: %s", claims.Email)
 
 	if !cfg.Cfg.AllowAllUsers {
 		if !jwtmanager.SiteInClaims(r.Host, &claims) {
-			error401(w, r, AuthError{"not authorized for " + r.Host, jwt})
+			if !cfg.Cfg.PublicAccess {
+				error401(w, r, AuthError{"not authorized for " + r.Host, jwt})
+			} else {
+				w.Header().Add("X-Lasso-User", "");
+			}
 			return
 		}
 	}


### PR DESCRIPTION
was previously returning 401 when an invalid JWT was sent, rather than allowing but setting the user to a blank string