### PR TITLE
add support for OpenID Connect providers, use all generic config

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -1,22 +1,21 @@
-
 # lasso config
-
-
 lasso:
   # logLevel: debug
   logLevel: info
   listen: 0.0.0.0
   port: 9090
-  # set allowAllUsers: true to use Lasso to just identify users rather than determine whether they are authorized
+  # set allowAllUsers: true to use Lasso to just accept anyone who can authenticate at the configured provider
   allowAllUsers: false
-  # Setting publicAccess: true will accept all requests, even without a cookie. If the user is logged in, the cookie will be validated and the user header will be set.
+  # Setting publicAccess: true will accept all requests, even without a cookie. 
+  # If the user is logged in, the cookie will be validated and the user header will be set.
+  # You will need to direct people to the Lasso login page from your application.
   publicAccess: false
   # each of these domains must serve the url https://lasso.$domains[0] https://lasso.$domains[1] ...
-  # usually you'll just have one
+  # usually you'll just have one.
+  # Comment this out if you set allowAllUser:true
   domains:
   - yourdomain.com
   - yourotherdomain.com
-  # gets sent to google as a primer
   jwt:
     issuer: Lasso
     maxAge: 240
@@ -24,10 +23,10 @@ lasso:
     compress: true
   cookie: 
     # name of cookie to store the jwt
-    name: Lasso
+    name: Lasso-cookie
     # optionally force the domain of the cookie to set
     # domain: yourdomain.com
-    secure: false
+    secure: true
     httpOnly: true
   headers:
     jwt: X-Lasso-Token
@@ -36,50 +35,56 @@ lasso:
   db: 
     file: data/lasso_bolt.db
   session:
-    name: lasso
-  test_url: http://my.testing.site.com
+    name: lasso-session
+  test_url: http://yourdomain.com
 
 #
-# OAuth Config
+# OAuth Provider Config
 #
 oauth:
-  # configure one of the following
-  google:
-    # create new credentials at:
-    # https://console.developers.google.com/apis/credentials
-    client_id: 
-    client_secret: 
-    # must be the /auth endpoint
-    callback_urls:
-      - http://lasso.yourdomain.com:9090/auth
-      - http://lasso.yourotherdomain.com:9090/auth
-    preferredDomain: yourdomain.com
-  generic:
-    # create new credentials at:
-    # https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
-    provider: github
-    client_id:
-    client_secret:
-    auth_url: https://github.com/login/oauth/authorize
-    token_url: https://github.com/login/oauth/access_token
-    # callback_url is configured at github.com when setting up the app
-    scopes:
-      - user
-    user_info_url: https://api.github.com/user?access_token=
-  generic:
-    # https://indieauth.com/developers
-    provider: indieauth
-    client_id: http://yourdomain.com
-    # must be the /auth endpoint
-    auth_url: https://indieauth.com/auth
-    user_info_url: https://indieauth.com/auth
-    callback_url: http://lasso.yourdomain.com:9090/auth
-  generic:
-    # https://indieauth.com/developers
-    provider: indieauth
-    client_id: http://yourdomain.com
-    # must be the /auth endpoint
-    auth_url: https://indieauth.com/auth
-    user_info_url: https://indieauth.com/auth
-    callback_url: http://lasso.yourdomain.com:9090/auth
+  # configure only one of the following
+
+  # Google
+  provider: google
+  # create new credentials at:
+  # https://console.developers.google.com/apis/credentials
+  client_id: 
+  client_secret: 
+  # must be the /auth endpoint
+  callback_urls:
+    - http://lasso.yourdomain.com:9090/auth
+    - http://lasso.yourotherdomain.com:9090/auth
+  preferredDomain: yourdomain.com
+
+  # GitHub
+  # https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
+  provider: github
+  client_id:
+  client_secret:
+  auth_url: https://github.com/login/oauth/authorize
+  token_url: https://github.com/login/oauth/access_token
+  # callback_url is configured at github.com when setting up the app
+  scopes:
+    - user
+  user_info_url: https://api.github.com/user?access_token=
+
+  # Generic OpenID Connect
+  provider: oidc
+  client_id: 
+  client_secret: 
+  auth_url: https://{yourOktaDomain}/oauth2/default/v1/authorize
+  token_url: https://{yourOktaDomain}/oauth2/default/v1/token
+  user_info_url: https://{yourOktaDomain}/oauth2/default/v1/userinfo
+  scopes:
+    - openid
+    - email
+    - profile
+  callback_url: http://lasso.yourdomain.com:9090/auth
+
+  # IndieAuth
+  # https://indielogin.com/api
+  provider: indieauth
+  client_id: http://yourdomain.com
+  auth_url: https://indielogin.com/auth
+  callback_url: http://lasso.yourdomain.com:9090/auth
   

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -450,6 +450,28 @@ func getUserInfo(r *http.Request, user *structs.User) error {
 		return getUserInfoFromGoogle(client, user)
 	} else if genOauth.Provider == "github" {
 		return getUserInfoFromGithub(client, user, providerToken)
+	} else if genOauth.Provider == "oidc" {
+		return getUserInfoFromOpenID(client, user, providerToken)
+	} else {
+		log.Error("we don't know how to look up the user info")
+	}
+	return nil
+}
+
+func getUserInfoFromOpenID(client *http.Client, user *structs.User, ptoken *oauth2.Token) error {
+	userinfo, err := client.Get(genOauth.UserInfoURL)
+	if err != nil {
+		// http.Error(w, err.Error(), http.StatusBadRequest)
+		return err
+	}
+	defer userinfo.Body.Close()
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Println("OpenID userinfo body: ", string(data))
+	if err = json.Unmarshal(data, user); err != nil {
+		log.Errorln(err)
+		// renderIndex(w, "Error marshalling response. Please try agian.")
+		// c.HTML(http.StatusBadRequest, "error.tmpl", gin.H{"message": })
+		return err
 	}
 	return nil
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -40,7 +40,6 @@ type AuthError struct {
 }
 
 var (
-	gcred       structs.GCredentials
 	genOauth    structs.GenericOauth
 	oauthclient *oauth2.Config
 	oauthopts   oauth2.AuthCodeOption
@@ -54,37 +53,34 @@ var (
 func init() {
 	log.Debug("init handlers")
 
-	// if grcred exist
-	err := cfg.UnmarshalKey("oauth.google", &gcred)
-	if err == nil && gcred.ClientID != "" {
-		log.Info("configuring google oauth")
-		oauthclient = &oauth2.Config{
-			ClientID:     gcred.ClientID,
-			ClientSecret: gcred.ClientSecret,
-			// RedirectURL:  gcred.RedirectURL,
-			Scopes: []string{
-				// You have to select a scope from
-				// https://developers.google.com/identity/protocols/googlescopes#google_sign-in
-				"https://www.googleapis.com/auth/userinfo.email",
-			},
-			Endpoint: google.Endpoint,
-		}
-		log.Infof("setting google oauth prefered login domain param 'hd' to %s", gcred.PreferredDomain)
-		oauthopts = oauth2.SetAuthURLParam("hd", gcred.PreferredDomain)
-		return
-	}
-	err = cfg.UnmarshalKey("oauth.generic", &genOauth)
+	err := cfg.UnmarshalKey("oauth", &genOauth)
 	if err == nil {
-		log.Info("configuring generic oauth")
-		oauthclient = &oauth2.Config{
-			ClientID:     genOauth.ClientID,
-			ClientSecret: genOauth.ClientSecret,
-			Endpoint: oauth2.Endpoint{
-				AuthURL:  genOauth.AuthURL,
-				TokenURL: genOauth.TokenURL,
-			},
-			RedirectURL: genOauth.RedirectURL,
-			Scopes:      genOauth.Scopes,
+		if genOauth.Provider == "google" {
+			log.Info("configuring google oauth")
+			oauthclient = &oauth2.Config{
+				ClientID:     genOauth.ClientID,
+				ClientSecret: genOauth.ClientSecret,
+				Scopes: []string{
+					// You have to select a scope from
+					// https://developers.google.com/identity/protocols/googlescopes#google_sign-in
+					"https://www.googleapis.com/auth/userinfo.email",
+				},
+				Endpoint: google.Endpoint,
+			}
+			log.Infof("setting google oauth preferred login domain param 'hd' to %s", genOauth.PreferredDomain)
+			oauthopts = oauth2.SetAuthURLParam("hd", genOauth.PreferredDomain)
+		} else {
+			log.Info("configuring generic oauth")
+			oauthclient = &oauth2.Config{
+				ClientID:     genOauth.ClientID,
+				ClientSecret: genOauth.ClientSecret,
+				Endpoint: oauth2.Endpoint{
+					AuthURL:  genOauth.AuthURL,
+					TokenURL: genOauth.TokenURL,
+				},
+				RedirectURL: genOauth.RedirectURL,
+				Scopes:      genOauth.Scopes,
+			}
 		}
 	}
 }
@@ -99,11 +95,11 @@ func loginURL(r *http.Request, state string) string {
 	// State can be some kind of random generated hash string.
 	// See relevant RFC: http://tools.ietf.org/html/rfc6749#section-10.12
 	var url = ""
-	if gcred.ClientID != "" {
+	if genOauth.Provider == "google" {
 		// If the provider is Google, find a matching redirect URL to use for the client
 		domain := domains.Matches(r.Host)
 		log.Debugf("looking for redirect URL matching  %v", domain)
-		for i, v := range gcred.RedirectURLs {
+		for i, v := range genOauth.RedirectURLs {
 			log.Debugf("redirect value matched at [%d]=%v", i, v)
 			if strings.Contains(v, domain) {
 				oauthclient.RedirectURL = v
@@ -401,7 +397,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	if ok, err := VerifyUser(user); !ok {
 		log.Error(err)
-		renderIndex(w, fmt.Sprintf("User is not authorized. %s Please try agian.", err))
+		renderIndex(w, fmt.Sprintf("User is not authorized. %s Please try again.", err))
 		return
 	}
 
@@ -444,9 +440,10 @@ func getUserInfo(r *http.Request, user *structs.User) error {
 	if err != nil {
 		return err
 	}
+
 	// make the "third leg" request back to google to exchange the token for the userinfo
 	client := oauthclient.Client(oauth2.NoContext, providerToken)
-	if gcred.ClientID != "" {
+	if genOauth.Provider == "google" {
 		return getUserInfoFromGoogle(client, user)
 	} else if genOauth.Provider == "github" {
 		return getUserInfoFromGithub(client, user, providerToken)

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -31,15 +31,6 @@ type GithubUser struct {
 	// jwt.StandardClaims
 }
 
-// GCredentials google credentials
-// loaded from yaml config
-type GCredentials struct {
-	ClientID        string   `mapstructure:"client_id"`
-	ClientSecret    string   `mapstructure:"client_secret"`
-	RedirectURLs    []string `mapstructure:"callback_urls"`
-	PreferredDomain string   `mapstructre:"preferredDomain"`
-}
-
 // GenericOauth provides endoint for access
 type GenericOauth struct {
 	ClientID     string   `mapstructure:"client_id"`
@@ -47,9 +38,11 @@ type GenericOauth struct {
 	AuthURL      string   `mapstructure:"auth_url"`
 	TokenURL     string   `mapstructure:"token_url"`
 	RedirectURL  string   `mapstructure:"callback_url"`
+	RedirectURLs    []string `mapstructure:"callback_urls"`
 	Scopes       []string `mapstructure:"scopes"`
 	UserInfoURL  string   `mapstructure:"user_info_url"`
 	Provider     string   `mapstructure:"provider"`
+	PreferredDomain string `mapstructre:"preferredDomain"`
 }
 
 // Team has members and provides acess to sites


### PR DESCRIPTION
* add support for OpenID Connect providers
* drop special-casing google config
* changes config file format to drop the extra level of nesting
* update example config with more explanations
* Use more different names for lasso cookie vs session to be less confused when looking at the debug logs